### PR TITLE
FEATURE: better validation error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ yarn add -D prisma-mongo-json-schema-generator
 **2. Apply the schema to database**
 
 ```shell
-PRISMA_SCHEMA_FILE=prisma/prisma.schema MONGO_URI=mongodb://localhost:27017/your-database yarn prisma-mongo-json-schema-generator-apply
+PRISMA_SCHEMA_FILE=prisma/schema.prisma MONGO_URI=mongodb://localhost:27017/your-database yarn prisma-mongo-json-schema-generator-apply
 ```
 
 If you are getting `AuthenticationFailed` errors, make sure that you are specifying the correct auth database in the connection URI by using the `authSource` query parameter (ex: `authSource=admin`).
@@ -45,7 +45,7 @@ The package is configurable via environment variables:
 | Env name | Default value |
 |--|--|
 | MONGO_URI | required |
-| PRISMA_SCHEMA_FILE | `prisma/prisma.schema` |
+| PRISMA_SCHEMA_FILE | `prisma/schema.prisma` |
 | VALIDATION_LEVEL | `strict` |
 | VALIDATION_ACTION | `error` |
 
@@ -61,5 +61,5 @@ model SomeModel {
 **3. Validate collections according to the schema**
 
 ```shell
-PRISMA_SCHEMA_FILE=prisma/prisma.schema MONGO_URI=mongodb://localhost:27017/your-database yarn prisma-mongo-json-schema-generator-verify
+PRISMA_SCHEMA_FILE=prisma/schema.prisma MONGO_URI=mongodb://localhost:27017/your-databse yarn prisma-mongo-json-schema-generator-verify
 ```

--- a/src/scripts/verifyMongoSchema.ts
+++ b/src/scripts/verifyMongoSchema.ts
@@ -23,10 +23,50 @@ export const verifyMongoSchema = async (schema: {
                             ],
                         })
                     if (firstFailedDocument) {
-                        console.info(
-                            `❌ Collection ${collectionName} failed validation, first failed document is: `,
-                            firstFailedDocument,
-                        )
+                        try {
+                            // In order to provide some better debug information, we try to update the first failed document in hopes of getting `schemaRulesNotSatisfied` information
+                            await database.collection(collectionName).updateOne(
+                                { _id: firstFailedDocument._id },
+                                {
+                                    $set: {
+                                        ___schmaValidator: Math.random(),
+                                    },
+                                },
+                            )
+                            // We shouldn't have gotten to this point, the previous update should have thrown due to failed $jsonSchema constraints.
+                            // If it didn't, it probably means that we forgot to `apply` the schema or that the validation action is not "error"
+                            console.warn(
+                                'Not able to provide the full debug info, make sure that you have applied the schema with `VALIDATION_LEVEL=strict VALIDATION_ACTION=error`',
+                            )
+                            console.info(
+                                `❌ Collection ${collectionName} failed validation, first failed document is: `,
+                                firstFailedDocument,
+                            )
+                            // Cleanup
+                            await database.collection(collectionName).updateOne(
+                                { _id: firstFailedDocument._id },
+                                {
+                                    $unset: {
+                                        ___schmaValidator: '',
+                                    },
+                                },
+                            )
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        } catch (e: any) {
+                            console.info(
+                                `❌ Collection ${collectionName} failed validation, first failed document is: `,
+                                firstFailedDocument,
+                            )
+                            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                            if (e?.errInfo?.details?.schemaRulesNotSatisfied) {
+                                console.log('Reason for failure:')
+                                console.dir(
+                                    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                                    e.errInfo.details.schemaRulesNotSatisfied,
+                                    { depth: null },
+                                )
+                            }
+                        }
                     } else {
                         console.info(
                             `✅ Collection ${collectionName} passed validation`,


### PR DESCRIPTION
There's no straighforward way to figure out why a certain document doesn't match `$jsonSchema`.

But there's a hack: try to modify a document with some fake field and get validation results then.

![image](https://user-images.githubusercontent.com/837032/196500784-0298b621-835e-49bf-b04c-fefde35e4121.png)
